### PR TITLE
Correction needed to build with libtorrent >= 1.0

### DIFF
--- a/createtorrent.cpp
+++ b/createtorrent.cpp
@@ -54,7 +54,7 @@ void CreateTorrent::makeTorrentFiles(QString source, QString outputLocation, boo
 }
 
 // Courtesy of qBitTorrent
-#if LIBTORRENT_VERSION_MINOR >= 16
+#if LIBTORRENT_VERSION_MINOR >= 16 || LIBTORRENT_VERSION_MAJOR >= 1
 bool file_filter(std::string const& f)
 {
         if (libtorrent::filename(f)[0] == '.') return false;

--- a/createtorrent.h
+++ b/createtorrent.h
@@ -31,7 +31,7 @@
 #endif
 
 #include <libtorrent/version.hpp>
-#if LIBTORRENT_VERSION_MINOR < 16
+#if LIBTORRENT_VERSION_MINOR < 16 && LIBTORRENT_VERSION_MAJOR < 1
 #define BOOST_FILESYSTEM_VERSION 2
 #endif
 


### PR DESCRIPTION
Libtorrent is now in version 1.0 so conditions needed to be updated to take into acount the change in version number.
